### PR TITLE
fix: add check if the POST request was for login

### DIFF
--- a/frontend/src/game/apiService.ts
+++ b/frontend/src/game/apiService.ts
@@ -66,8 +66,8 @@ export class ApiService {
                 // Token expired, trigger refresh
                 if (endpoint === '/users/auth/login'){
                     const error: any = new Error('Unauthorized: Invalid credentials');
-                    error.status = 401
-                    throw error
+                    error.status = 401;
+                    throw error;
                 }
                 const { UserService } = await import('./userService');
                 console.log('[API] 401 Unauthorized - Attempting refresh...');


### PR DESCRIPTION
Fix: #70 

**Problem**:
- In current build when the login credential are wrong apiservice function is continuously fetching for the new token. Which create a infinite loop.

**Solution**:
- Added additional check when the route is for login it will throw a error rather then fetch new token